### PR TITLE
Add file site.xml and add 'junit-jupiter-engine' to build to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-<!--
-    <body>
-        <menu ref="reports"/>
-        <menu>
-            <item name="Code Coverage Report" href="index.html"/>
-        </menu>
-    </body>
--->
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exchange.app</groupId>
     <artifactId>exchange</artifactId>
@@ -23,92 +14,68 @@
             <artifactId>joda-time</artifactId>
             <version>2.10.5</version>
         </dependency>
-        <dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.21.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.14.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <version>1.48</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
-            <groupId>org.junit.platform</groupId>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <main.class>pl.koziolekweb.pwm.HelloWorld</main.class>
+    <java.version>11</java.version>
+    <junit.jupiter.version>5.4.2</junit.jupiter.version>
+    <pitest.version>1.4.10</pitest.version>
+    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+    <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
+    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
 
-            <artifactId>junit-platform-surefire-provider</artifactId>
-
-            <version>1.3.2</version>
-
-        </dependency>
-        <dependency>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <dependencies>
+          <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.21.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.14.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>1.48</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <main.class>pl.koziolekweb.pwm.HelloWorld</main.class>
-        <java.version>11</java.version>
-        <junit.jupiter.version>5.4.2</junit.jupiter.version>
-        <pitest.version>1.4.10</pitest.version>
-        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
-        <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
-
-    </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-                <dependencies>
-
-                <dependency>
-
-                    <groupId>org.junit.platform</groupId>
-
-                    <artifactId>junit-platform-surefire-provider</artifactId>
-
-                    <version>1.3.2</version>
-
-                </dependency>
-
-                <dependency>
-
-                    <groupId>org.junit.jupiter</groupId>
-
-                    <artifactId>junit-jupiter-engine</artifactId>
-
-                    <version>5.5.2</version>
-
-                </dependency>
-                </dependencies>
-                <configuration>
-                    <argLine>
-                        -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar
-                        -Dcoverage-output=html             <!-- or html-cp, serial, serial-append; if not set, defaults to "html" -->
-                        -Dcoverage-classes=loaded          <!-- or a "*" expression for class names; if not set, measures all production code classes -->
-                        -Dcoverage-outputDir="target/coverage-report"        <!-- default: target/coverage-report -->
-                        -Dcoverage-srcDirs="src"         <!-- default: all "src" directories -->
-                        -Dcoverage-check=80                <!-- default: no checks -->
-                    </argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+            <version>5.5.2</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <argLine>
+            -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar
+            -Dcoverage-output=html             <!-- or html-cp, serial, serial-append; if not set, defaults to "html" -->
+            -Dcoverage-classes=loaded          <!-- or a "*" expression for class names; if not set, measures all production code classes -->
+            -Dcoverage-outputDir="target/coverage-report"        <!-- default: target/coverage-report -->
+            -Dcoverage-srcDirs="src"         <!-- default: all "src" directories -->
+            -Dcoverage-check=80                <!-- default: no checks -->
+          </argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,68 +14,60 @@
             <artifactId>joda-time</artifactId>
             <version>2.10.5</version>
         </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.3.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.21.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.14.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
-      <version>1.48</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <main.class>pl.koziolekweb.pwm.HelloWorld</main.class>
-    <java.version>11</java.version>
-    <junit.jupiter.version>5.4.2</junit.jupiter.version>
-    <pitest.version>1.4.10</pitest.version>
-    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
-    <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
-    <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
-
-  </properties>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-        <dependencies>
-          <dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <argLine>
-            -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar
-            -Dcoverage-output=html             <!-- or html-cp, serial, serial-append; if not set, defaults to "html" -->
-            -Dcoverage-classes=loaded          <!-- or a "*" expression for class names; if not set, measures all production code classes -->
-            -Dcoverage-outputDir="target/coverage-report"        <!-- default: target/coverage-report -->
-            -Dcoverage-srcDirs="src"         <!-- default: all "src" directories -->
-            -Dcoverage-check=80                <!-- default: no checks -->
-          </argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.21.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.14.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.48</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.6.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar
+                        -Dcoverage-output=html             <!-- or html-cp, serial, serial-append; if not set, defaults to "html" -->
+                        -Dcoverage-classes=loaded          <!-- or a "*" expression for class names; if not set, measures all production code classes -->
+                        -Dcoverage-outputDir="target/coverage-report"        <!-- default: target/coverage-report -->
+                        -Dcoverage-srcDirs="src"         <!-- default: all "src" directories -->
+                        -Dcoverage-check=80                <!-- default: no checks -->
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<!--
     <body>
         <menu ref="reports"/>
         <menu>
             <item name="Code Coverage Report" href="index.html"/>
         </menu>
     </body>
+-->
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exchange.app</groupId>
     <artifactId>exchange</artifactId>
@@ -18,6 +22,15 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.10.5</version>
+        </dependency>
+        <dependency>
+
+            <groupId>org.junit.platform</groupId>
+
+            <artifactId>junit-platform-surefire-provider</artifactId>
+
+            <version>1.3.2</version>
+
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -47,12 +60,44 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <main.class>pl.koziolekweb.pwm.HelloWorld</main.class>
+        <java.version>11</java.version>
+        <junit.jupiter.version>5.4.2</junit.jupiter.version>
+        <pitest.version>1.4.10</pitest.version>
+        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+        <maven.jar.plugin.version>3.1.1</maven.jar.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
+
     </properties>
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <dependencies>
+
+                <dependency>
+
+                    <groupId>org.junit.platform</groupId>
+
+                    <artifactId>junit-platform-surefire-provider</artifactId>
+
+                    <version>1.3.2</version>
+
+                </dependency>
+
+                <dependency>
+
+                    <groupId>org.junit.jupiter</groupId>
+
+                    <artifactId>junit-jupiter-engine</artifactId>
+
+                    <version>5.5.2</version>
+
+                </dependency>
+                </dependencies>
                 <configuration>
                     <argLine>
                         -javaagent:${settings.localRepository}/org/jmockit/jmockit/1.48/jmockit-1.48.jar

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     http://maven.apache.org/maven-v4_0_0.xsd">
 
-
+<!--  https://jmockit.github.io/tutorial/CodeCoverage.html-->
   <body>
     <menu ref="reports"/>
     <menu>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+    http://maven.apache.org/maven-v4_0_0.xsd">
+
+
+  <body>
+    <menu ref="reports"/>
+    <menu>
+      <item name="__ Code Coverage Report __" href="index.html"/>
+    </menu>
+  </body>
+</project>


### PR DESCRIPTION
1. I moved section body from pom.xml to src/site/site.xml as in the documentation: https://jmockit.github.io/tutorial/CodeCoverage.html. This is needed to run maven on the console.

2. I added dependency 'junit-jupiter-engine' also to artifact maven-surefire-plugin in pom.xml build section. With out it tests not running in console.

I'll wrote few words in Slack later, because I have to make up material on 4developers.